### PR TITLE
Do not enforce `io::Error` as `Error` type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ parsed/serialized items using the bincode format.
 [dependencies]
 futures = "0.1"
 bytes = "0.4"
-tokio-serde = "0.1"
+tokio-serde = "0.2"
 serde = "1.0"
 bincode = "0.8"


### PR DESCRIPTION
Use `From<bincode::Error>` as constraint for the required `Error` type.