### PR TITLE
Update bincode/tokio_serde versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ parsed/serialized items using the bincode format.
 [dependencies]
 futures = "0.1"
 bytes = "0.4"
-tokio-serde = "0.2"
+tokio-serde = "0.3"
 serde = "1.0"
-bincode = "0.8"
+bincode = "1.0"


### PR DESCRIPTION
The tokio_serde signatures have changed (Bytes vs BytesMut). I am not sure if we need to bump the version as it was not published to crates.io