### PR TITLE
Add explicit type annotations to examples

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,10 +1,12 @@
 extern crate bincode;
+extern crate futures;
 #[macro_use]
 extern crate serde_derive;
 extern crate tokio;
 extern crate tokio_serde_bincode;
 
-use tokio::codec::length_delimited;
+use futures::sink;
+use tokio::codec::{FramedWrite, LengthDelimitedCodec, length_delimited};
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 use tokio_serde_bincode::WriteBincode;
@@ -17,6 +19,15 @@ struct Data {
     field: i32,
 }
 
+// FramedWrite upgrades TcpStream from an AsyncWrite to a Sink
+type IOErrorSink = FramedWrite<TcpStream, LengthDelimitedCodec>;
+
+// sink::SinkFromErr maps underlying IO errors into Bincode errors
+type BincodeErrSink = sink::SinkFromErr<IOErrorSink, bincode::Error>;
+
+// WriteBincode maps Bincode-serializeable structs into bytes
+type BincodeSink = WriteBincode<BincodeErrSink, Data>;
+
 pub fn main() -> Result<(), Box<std::error::Error>> {
     let addr = "127.0.0.1:17653".parse()?;
 
@@ -25,12 +36,11 @@ pub fn main() -> Result<(), Box<std::error::Error>> {
         .from_err()
         .and_then(|socket| {
             // Delimit frames using length prefix
-            let delimited_sink = length_delimited::Builder::new()
+            let delimited_sink: BincodeErrSink = length_delimited::Builder::new()
                 .new_write(socket)
                 .sink_from_err::<bincode::Error>();
-
             // Serialize frames
-            let serialized: WriteBincode<_, Data> = WriteBincode::new(delimited_sink);
+            let serialized: BincodeSink = WriteBincode::new(delimited_sink);
             serialized.send(Data { field: 42 }).map(|_result| ())
         })
         .map_err(|err| println!("Error {:?}", err));


### PR DESCRIPTION
I wanted to store the `ReadBincode` and `WriteBincode` wrappers as struct fields, and it took me a while to figure out what the correct types were.

Hopefully this will help someone in the future with the same issue?